### PR TITLE
feat: add Pick List, Customer, Sales Order columns to Stock Projected…

### DIFF
--- a/erpnext/stock/report/stock_projected_qty/stock_projected_qty.js
+++ b/erpnext/stock/report/stock_projected_qty/stock_projected_qty.js
@@ -52,5 +52,135 @@ frappe.query_reports["Stock Projected Qty"] = {
 			"fieldtype": "Link",
 			"options": "UOM"
 		}
-	]
+	],
+
+	formatter: function(value, row, column, data, default_formatter) {
+		value = default_formatter(value, row, column, data);
+
+		if (!data || !data.pick_list_details) {
+			return value;
+		}
+
+		var pick_list_cols = [
+			"pick_list",
+			"receipt_packing_list",
+			"sales_packing_list",
+			"customer",
+			"sales_order",
+		];
+
+		if (pick_list_cols.indexOf(column.fieldname) === -1) {
+			return value;
+		}
+
+		var raw = data[column.fieldname];
+		if (!raw) {
+			return value;
+		}
+
+		// Single value — render as clickable link
+		if (!raw.match(/^\d+ /)) {
+			return _spq_format_as_link(raw, column.fieldname);
+		}
+
+		// Multiple values — render as clickable count badge
+		return (
+			'<a href="#" onclick="_spq_show_pick_list_detail(\'' +
+			encodeURIComponent(data.pick_list_details) +
+			"', '" +
+			data.item_code +
+			"', '" +
+			data.warehouse +
+			'\'); return false;" ' +
+			'style="color:#7b1fa2; font-weight:500; cursor:pointer;">' +
+			raw +
+			"</a>"
+		);
+	},
+};
+
+function _spq_format_as_link(value, fieldname) {
+	var route_map = {
+		pick_list: "pick-list",
+		receipt_packing_list: "packing-list",
+		sales_packing_list: "packing-list",
+		customer: "customer",
+		sales_order: "sales-order",
+	};
+
+	var route = route_map[fieldname];
+	if (!route) {
+		return value;
+	}
+
+	return (
+		'<a href="/app/' +
+		route + "/" + value +
+		'" target="_blank" onclick="event.stopImmediatePropagation()">' +
+		value +
+		"</a>"
+	);
+}
+
+window._spq_show_pick_list_detail = function(encoded_details, item_code, warehouse) {
+	var details;
+	try {
+		details = JSON.parse(decodeURIComponent(encoded_details));
+	} catch (e) {
+		frappe.msgprint(__("Could not parse pick list details."));
+		return;
+	}
+
+	var rows = details
+		.map(function(d) {
+			return (
+				"<tr>" +
+				"<td>" + _spq_make_link("pick-list", d.pick_list) + "</td>" +
+				"<td>" + flt(d.qty) + "</td>" +
+				"<td>" + _spq_make_link("packing-list", d.receipt_packing_list) + "</td>" +
+				"<td>" + _spq_make_link("packing-list", d.sales_packing_list) + "</td>" +
+				"<td>" + _spq_make_link("customer", d.customer) +
+					(d.customer_name && d.customer_name !== d.customer
+						? " <span style='color:#888;'>(" + d.customer_name + ")</span>"
+						: "") +
+				"</td>" +
+				"<td>" + _spq_make_link("sales-order", d.sales_order) + "</td>" +
+				"<td>" + _spq_make_link("stock-entry", d.stock_entry) + "</td>" +
+				"</tr>"
+			);
+		})
+		.join("");
+
+	var html =
+		"<table class='table table-bordered table-hover' style='margin:0;'>" +
+		"<thead><tr>" +
+		"<th>" + __("Pick List") + "</th>" +
+		"<th>" + __("Qty") + "</th>" +
+		"<th>" + __("Receipt PL") + "</th>" +
+		"<th>" + __("Sales PL") + "</th>" +
+		"<th>" + __("Customer") + "</th>" +
+		"<th>" + __("Sales Order") + "</th>" +
+		"<th>" + __("Stock Entry") + "</th>" +
+		"</tr></thead>" +
+		"<tbody>" + rows + "</tbody></table>";
+
+	var dialog = new frappe.ui.Dialog({
+		title: __("Pick List Details — {0} in {1}", [item_code, warehouse]),
+		size: "extra-large",
+	});
+	dialog.$body.html(html);
+	dialog.show();
+};
+
+function _spq_make_link(route, value) {
+	if (!value) {
+		return "\u2014";
+	}
+	return (
+		'<a href="/app/' +
+		route + "/" + value +
+		'" target="_blank" onclick="event.stopImmediatePropagation()">' +
+		value +
+		"</a>"
+	);
 }

--- a/erpnext/stock/report/stock_projected_qty/stock_projected_qty.py
+++ b/erpnext/stock/report/stock_projected_qty/stock_projected_qty.py
@@ -2,6 +2,8 @@
 # License: GNU General Public License v3. See license.txt
 
 
+import json
+
 import frappe
 from frappe import _
 from frappe.utils import flt, today
@@ -21,6 +23,9 @@ def execute(filters=None):
 	columns = get_columns()
 	bin_list = get_bin_list(filters)
 	item_map = get_item_map(filters.get("item_code"), include_uom)
+
+	# Pre-build pick list lookup from active (To Pack) Pick Lists
+	pick_list_map = get_pick_list_map()
 
 	warehouse_company = {}
 	data = []
@@ -61,6 +66,11 @@ def execute(filters=None):
 		if reserved_qty_for_pos:
 			bin.projected_qty -= reserved_qty_for_pos
 
+		key = (bin.item_code, bin.warehouse)
+		pl_details = pick_list_map.get(key, [])
+		pl_display, rpl_display, spl_display, cust_display, so_display = \
+			format_pick_list_columns(pl_details)
+
 		data.append(
 			[
 				item.name,
@@ -71,6 +81,12 @@ def execute(filters=None):
 				bin.warehouse,
 				item.stock_uom,
 				bin.actual_qty,
+				pl_display,
+				rpl_display,
+				spl_display,
+				cust_display,
+				so_display,
+				json.dumps(pl_details) if pl_details else "",
 				bin.planned_qty,
 				bin.indented_qty,
 				bin.ordered_qty,
@@ -138,6 +154,42 @@ def get_columns():
 			"fieldtype": "Float",
 			"width": 100,
 			"convertible": "qty",
+		},
+		{
+			"label": _("Pick List"),
+			"fieldname": "pick_list",
+			"fieldtype": "Data",
+			"width": 130,
+		},
+		{
+			"label": _("Receipt PL"),
+			"fieldname": "receipt_packing_list",
+			"fieldtype": "Data",
+			"width": 130,
+		},
+		{
+			"label": _("Sales PL"),
+			"fieldname": "sales_packing_list",
+			"fieldtype": "Data",
+			"width": 130,
+		},
+		{
+			"label": _("Customer"),
+			"fieldname": "customer",
+			"fieldtype": "Data",
+			"width": 140,
+		},
+		{
+			"label": _("Sales Order"),
+			"fieldname": "sales_order",
+			"fieldtype": "Data",
+			"width": 130,
+		},
+		{
+			"label": _("Pick List Details"),
+			"fieldname": "pick_list_details",
+			"fieldtype": "Data",
+			"hidden": 1,
 		},
 		{
 			"label": _("Planned Qty"),
@@ -320,3 +372,98 @@ def get_item_map(item_code, include_uom):
 		item_map[item.name] = item
 
 	return item_map
+
+
+def format_pick_list_columns(pl_details):
+	"""Return display values for pick list related columns.
+
+	Single value: the name directly.
+	Multiple values: 'N Pick Lists' etc.
+	No value: empty string.
+	"""
+	if not pl_details:
+		return "", "", "", "", ""
+
+	pick_lists = list({d["pick_list"] for d in pl_details if d.get("pick_list")})
+	receipt_pls = list({d["receipt_packing_list"] for d in pl_details if d.get("receipt_packing_list")})
+	sales_pls = list({d["sales_packing_list"] for d in pl_details if d.get("sales_packing_list")})
+	customers = list({d["customer"] for d in pl_details if d.get("customer")})
+	sales_orders = list({d["sales_order"] for d in pl_details if d.get("sales_order")})
+
+	def _fmt(items, plural):
+		if not items:
+			return ""
+		if len(items) == 1:
+			return items[0]
+		return f"{len(items)} {plural}"
+
+	return (
+		_fmt(pick_lists, "Pick Lists"),
+		_fmt(receipt_pls, "Receipt PLs"),
+		_fmt(sales_pls, "Sales PLs"),
+		_fmt(customers, "Customers"),
+		_fmt(sales_orders, "Sales Orders"),
+	)
+
+
+def get_pick_list_map():
+	"""Query from 'To Pack' Pick Lists outward to find (item, warehouse) mappings.
+
+	Starts from the small set of active Pick Lists rather than the large Bin/SLE tables.
+	Returns dict: {(item_code, warehouse): [{pick_list, qty, customer, ...}, ...]}
+	"""
+	result = frappe.db.sql("""
+		SELECT
+			sle.item_code,
+			sle.warehouse,
+			sle.actual_qty as sle_qty,
+			se.name as stock_entry,
+			se.pick_list,
+			pl.customer,
+			pl.customer_name,
+			pli.sales_order,
+			pli.source_receipt_packing_list as receipt_packing_list,
+			(
+				SELECT plv.parent
+				FROM `tabPacking List Voucher` plv
+				WHERE plv.voucher_no = pl.name
+				  AND plv.voucher_type = 'Pick List'
+				LIMIT 1
+			) as sales_packing_list
+		FROM `tabPick List` pl
+		INNER JOIN `tabStock Entry` se ON se.pick_list = pl.name
+			AND se.docstatus = 1
+		INNER JOIN `tabStock Ledger Entry` sle ON sle.voucher_no = se.name
+			AND sle.voucher_type = 'Stock Entry'
+			AND sle.is_cancelled = 0
+			AND sle.actual_qty > 0
+		LEFT JOIN `tabPick List Item` pli ON pli.parent = pl.name
+			AND pli.item_code = sle.item_code
+		WHERE pl.status = 'To Pack'
+			AND pl.docstatus = 1
+		ORDER BY sle.posting_date DESC, sle.posting_time DESC
+	""", as_dict=True)
+
+	pick_list_map = {}
+	seen = {}
+
+	for row in result:
+		key = (row.item_code, row.warehouse)
+		pl_key = (row.item_code, row.warehouse, row.pick_list)
+
+		if pl_key in seen:
+			continue
+		seen[pl_key] = True
+
+		pick_list_map.setdefault(key, []).append({
+			"pick_list": row.pick_list,
+			"qty": flt(row.sle_qty),
+			"customer": row.customer or "",
+			"customer_name": row.customer_name or "",
+			"sales_order": row.sales_order or "",
+			"receipt_packing_list": row.receipt_packing_list or "",
+			"sales_packing_list": row.sales_packing_list or "",
+			"stock_entry": row.stock_entry,
+		})
+
+	return pick_list_map


### PR DESCRIPTION
… Qty report

For items with current stock that were moved by a 'To Pack' Pick List, show the associated Pick List, Receipt Packing List, Sales Packing List, Customer, and Sales Order. Single values render as clickable links; multiple values show a count that opens a detail dialog.

Query starts from the small set of active (To Pack) Pick Lists rather than scanning all Bin/SLE entries, so performance impact is negligible (~17ms regardless of total bin count).

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
