### PR TITLE
fix: fold NULL-payment_term refs into per-term outstanding via FIFO

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1695,6 +1695,26 @@ def get_split_invoice_rows(
 			)
 		)
 
+	# Fold orphan-payment allocations (submitted PE refs with NULL payment_term) into
+	# per-term outstanding via FIFO. Without this, Payment Reconciliation / Payment
+	# Entry would still offer to allocate against term amounts that were already paid
+	# at the invoice (PLE) level by NULL-term refs.
+	if split_rows:
+		from erpnext.accounts.utils import distribute_orphan_payment_to_terms
+
+		distribute_orphan_payment_to_terms(
+			invoice.voucher_type,
+			invoice.voucher_no,
+			split_rows,
+			outstanding_key="outstanding_amount",
+			due_date_key="due_date",
+		)
+		# Keep payment_term_outstanding aligned with outstanding_amount post-fold
+		for row in split_rows:
+			row["payment_term_outstanding"] = row["outstanding_amount"]
+		# Drop rows that became fully paid by orphan allocations
+		split_rows = [r for r in split_rows if flt(r["outstanding_amount"]) > 0.1]
+
 	return split_rows
 
 
@@ -2468,6 +2488,24 @@ def get_reference_as_per_payment_terms(
 					"allocated_amount": payment_term_outstanding,
 				}
 			)
+
+	# Fold orphan-payment allocations (submitted PE refs with NULL payment_term) into
+	# per-term outstanding via FIFO so a PE built from this invoice doesn't propose
+	# allocations against amounts already paid by NULL-term refs.
+	if references:
+		from erpnext.accounts.utils import distribute_orphan_payment_to_terms
+
+		distribute_orphan_payment_to_terms(
+			dt,
+			dn,
+			references,
+			outstanding_key="outstanding_amount",
+			due_date_key="due_date",
+		)
+		for ref in references:
+			ref["payment_term_outstanding"] = ref["outstanding_amount"]
+			ref["allocated_amount"] = ref["outstanding_amount"]
+		references = [r for r in references if flt(r["outstanding_amount"]) > 0.1]
 
 	return references
 

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -472,6 +472,20 @@ class ReceivablePayableReport(object):
 			if term.outstanding:
 				self.allocate_closing_to_term(row, term, "credit_note")
 
+		# Fold any orphan-payment allocations (PE refs with NULL payment_term) into the
+		# per-term outstanding via FIFO so the per-term view matches the invoice-level
+		# total. Without this, NULL-term payments only show up in the by-invoice view.
+		from erpnext.accounts.utils import distribute_orphan_payment_to_terms
+
+		distribute_orphan_payment_to_terms(
+			row.voucher_type,
+			row.voucher_no,
+			row.payment_terms,
+			outstanding_key="outstanding",
+			paid_key="paid",
+			due_date_key="due_date",
+		)
+
 		row.payment_terms = sorted(row.payment_terms, key=lambda x: x["due_date"])
 
 	def get_payment_terms(self, row):

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -434,6 +434,82 @@ def add_cc(args=None):
 	return cc.name
 
 
+def get_orphan_payment_term_allocation(reference_doctype, reference_name, exclude_payment_entry=None):
+	"""Sum of allocated_amount on submitted Payment Entry References that point at this
+	invoice but have no payment_term set.
+
+	These "orphan" allocations have already reduced the invoice's total outstanding via
+	the Payment Ledger Entry path, but Payment Schedule.paid_amount was never updated
+	(update_payment_schedule() in payment_entry.py skips refs with no payment_term).
+	Per-term outstanding views therefore over-report what is still owed.
+
+	Callers fold this amount across the invoice's payment schedule rows in due_date
+	(FIFO) order, so the per-term view matches the invoice-level view.
+
+	Pass exclude_payment_entry when the caller is itself a Payment Entry being edited —
+	its own submitted refs would otherwise double-count against the live form state.
+	"""
+	conditions = ""
+	values = [reference_doctype, reference_name]
+	if exclude_payment_entry:
+		conditions = "AND per.parent != %s"
+		values.append(exclude_payment_entry)
+
+	result = frappe.db.sql(
+		"""
+		SELECT COALESCE(SUM(per.allocated_amount), 0)
+		FROM `tabPayment Entry Reference` per
+		JOIN `tabPayment Entry` pe ON pe.name = per.parent AND pe.docstatus = 1
+		WHERE per.reference_doctype = %s
+		  AND per.reference_name = %s
+		  AND (per.payment_term IS NULL OR per.payment_term = '')
+		  {conditions}
+		""".format(conditions=conditions),
+		values,
+	)
+	return flt(result[0][0]) if result else 0.0
+
+
+def distribute_orphan_payment_to_terms(
+	reference_doctype,
+	reference_name,
+	terms,
+	outstanding_key="outstanding",
+	paid_key=None,
+	due_date_key="due_date",
+	exclude_payment_entry=None,
+):
+	"""Mutate `terms` in place: subtract orphan-payment allocations (NULL payment_term
+	refs on submitted Payment Entries) from each term's outstanding, FIFO by due_date.
+
+	If `paid_key` is provided, also add the absorbed amount to that field on each term
+	(useful for AR/AP report rows where "paid" is shown alongside "outstanding").
+
+	Returns the unallocated remainder (should normally be 0; positive means orphan
+	payments exceed total per-term outstanding, e.g. over-payment or rounding).
+	"""
+	orphan_amount = get_orphan_payment_term_allocation(
+		reference_doctype, reference_name, exclude_payment_entry=exclude_payment_entry
+	)
+	if not orphan_amount or not terms:
+		return orphan_amount
+
+	remaining = flt(orphan_amount)
+	for term in sorted(terms, key=lambda t: t.get(due_date_key) or getdate("9999-12-31")):
+		if remaining <= 0:
+			break
+		cap = flt(term.get(outstanding_key))
+		if cap <= 0:
+			continue
+		absorb = min(cap, remaining)
+		term[outstanding_key] = cap - absorb
+		if paid_key:
+			term[paid_key] = flt(term.get(paid_key)) + absorb
+		remaining -= absorb
+
+	return remaining
+
+
 def reconcile_against_document(args, skip_ref_details_update_for_pe=False):  # nosemgrep
 	"""
 	Cancel PE or JV, Update against document, split if required and resubmit


### PR DESCRIPTION
Closes #37

## Summary

- Add shared helper `distribute_orphan_payment_to_terms()` in `erpnext/accounts/utils.py` that, for a given invoice, sums NULL-`payment_term` allocations from submitted Payment Entry References and folds them into a list of term rows in due_date (FIFO) order
- Wire it into the three per-term outstanding read paths: AR/AP report, `get_split_invoice_rows()`, `get_reference_as_per_payment_terms()`
- No writes; invoice-level (PLE) outstanding unchanged

## Why a read-side fix instead of a write-side fix

NULL `payment_term` on a Payment Entry Reference is legitimate state — produced by manual row additions, by Payment Reconciliation's `update_reference_in_payment_entry` (which doesn't propagate term selection), and historically by PEs created before invoice-level split was enabled. The PLE path correctly reduces invoice-level outstanding regardless. Only the per-term view diverges, so that's where the reconciliation belongs.

This also means **no migration / no data fix**: the moment the new code runs, all three views agree.

## Test plan

- [ ] On dev, build AR/AP Statement PDF for supplier 500100232 — confirm AP-DA1255 still shows USD 13,100.88 (unchanged, by-invoice view)
- [ ] On dev, open Payment Reconciliation for supplier 500100232 — confirm AP-DA1255 Goods Payment row drops from USD 13,289.04 to USD 12,835.14 (absorbs $453.90)
- [ ] On dev, open a fresh Payment Entry against supplier 500100232 → "Get Outstanding Documents" — confirm AP-DA1255 per-term references reflect the folded amounts
- [ ] Confirm an invoice with no NULL-term refs is unchanged in all three views
- [ ] Confirm an invoice with no Payment Schedule (legacy or single-term) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)