### PR TITLE
fix: don't clobber return-row valuation_rate on internal-supplier repost

### DIFF
--- a/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
@@ -424,3 +424,86 @@ class TestRepostItemValuation(FrappeTestCase, StockTestMixin):
 
 		self.assertRaises(frappe.ValidationError, riv.save)
 		doc.cancel()
+
+
+class TestUpdateRateOnPurchaseReceiptGating(FrappeTestCase):
+	"""Regression tests for the internal-supplier valuation_rate overwrite gating.
+
+	update_rate_on_purchase_receipt used to overwrite the voucher item's
+	valuation_rate with the SLE outgoing rate for EVERY negative-qty PR/PI SLE of
+	an internal supplier. For ordinary inter-company RETURN rows (no
+	from_warehouse) that field is the validate-time invoice snapshot that
+	make_stock_adjustment_entry needs to regenerate the COGS gap line — the
+	overwrite made GL regeneration on repost permanently unbalanced (prod case
+	AP-DA1284: Debit and Credit not equal, difference -1.43 = per-unit landed
+	cost). The overwrite must fire ONLY for rows with from_warehouse set, whose
+	GL books the from-warehouse credit as valuation_rate * stock_qty.
+	"""
+
+	def _make_sle(self, voucher_type="Purchase Invoice"):
+		return frappe._dict(
+			{
+				"voucher_type": voucher_type,
+				"voucher_no": "TEST-VOUCHER-001",
+				"voucher_detail_no": "test-item-row-001",
+				"actual_qty": -1.0,
+				"outgoing_rate": 26.704,
+			}
+		)
+
+	def _run(self, sle, is_internal_supplier, from_warehouse, item_row_exists=True):
+		from unittest.mock import patch
+
+		from erpnext.stock.stock_ledger import update_entries_after
+
+		obj = update_entries_after.__new__(update_entries_after)
+
+		def cached_value(doctype, name, fieldname):
+			if fieldname == "is_internal_supplier":
+				return is_internal_supplier
+			if fieldname == "is_subcontracted":
+				return 0
+			return None
+
+		with patch("frappe.db.exists", return_value=item_row_exists), patch(
+			"frappe.get_cached_value", side_effect=cached_value
+		), patch("frappe.db.get_value", return_value=from_warehouse), patch(
+			"frappe.db.set_value"
+		) as set_value:
+			obj.update_rate_on_purchase_receipt(sle, 26.704)
+
+		return set_value
+
+	def test_no_overwrite_for_internal_supplier_return_without_from_warehouse(self):
+		"""The AP-DA1284 case: snapshot must survive the repost."""
+		for voucher_type in ("Purchase Invoice", "Purchase Receipt"):
+			sle = self._make_sle(voucher_type)
+			set_value = self._run(sle, is_internal_supplier=1, from_warehouse=None)
+			for c in set_value.call_args_list:
+				self.assertNotEqual(
+					c.args[2] if len(c.args) > 2 else c.kwargs.get("fieldname"),
+					"valuation_rate",
+					f"valuation_rate must not be overwritten for {voucher_type} return rows without from_warehouse",
+				)
+
+	def test_overwrite_kept_for_internal_transfer_row_with_from_warehouse(self):
+		"""Rows with from_warehouse book GL from valuation_rate — sync must continue."""
+		sle = self._make_sle()
+		set_value = self._run(sle, is_internal_supplier=1, from_warehouse="Stores - _TC")
+		set_value.assert_any_call(
+			"Purchase Invoice Item", sle.voucher_detail_no, "valuation_rate", sle.outgoing_rate
+		)
+
+	def test_no_overwrite_for_external_supplier(self):
+		sle = self._make_sle()
+		set_value = self._run(sle, is_internal_supplier=0, from_warehouse="Stores - _TC")
+		for c in set_value.call_args_list:
+			self.assertNotEqual(
+				c.args[2] if len(c.args) > 2 else c.kwargs.get("fieldname"), "valuation_rate"
+			)
+
+	def test_supplied_item_branch_untouched(self):
+		"""Old-flow subcontracting supplied rows (item row does not exist) keep their rate sync."""
+		sle = self._make_sle("Purchase Receipt")
+		set_value = self._run(sle, is_internal_supplier=1, from_warehouse=None, item_row_exists=False)
+		set_value.assert_any_call("Purchase Receipt Item Supplied", sle.voucher_detail_no, "rate", 26.704)

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -818,9 +818,20 @@ class update_entries_after(object):
 			if sle.voucher_type in ["Purchase Receipt", "Purchase Invoice"] and frappe.get_cached_value(
 				sle.voucher_type, sle.voucher_no, "is_internal_supplier"
 			):
-				frappe.db.set_value(
-					f"{sle.voucher_type} Item", sle.voucher_detail_no, "valuation_rate", sle.outgoing_rate
-				)
+				# Sync valuation_rate only for rows that consume it in GL: internal-transfer
+				# rows (from_warehouse set) book the from-warehouse credit as
+				# valuation_rate * stock_qty, so it must track the SLE outgoing rate.
+				# For ordinary inter-company RETURN rows the field is the validate-time
+				# invoice snapshot ((net + tax + landed cost) / qty) that
+				# make_stock_adjustment_entry compares against the SLE value to book the
+				# gap to COGS — overwriting it with the SLE rate erases that gap and makes
+				# GL regeneration on repost permanently unbalanced.
+				if frappe.db.get_value(
+					f"{sle.voucher_type} Item", sle.voucher_detail_no, "from_warehouse"
+				):
+					frappe.db.set_value(
+						f"{sle.voucher_type} Item", sle.voucher_detail_no, "valuation_rate", sle.outgoing_rate
+					)
 		else:
 			frappe.db.set_value(
 				"Purchase Receipt Item Supplied", sle.voucher_detail_no, "rate", outgoing_rate


### PR DESCRIPTION
Closes #40

## What

`update_rate_on_purchase_receipt` now overwrites the voucher item's `valuation_rate` with the SLE outgoing rate **only for rows with `from_warehouse`** (internal-transfer rows, whose GL books the from-warehouse credit as `valuation_rate × stock_qty`). Ordinary inter-company return rows keep their validate-time invoice snapshot.

## Why

The unconditional overwrite destroyed the baseline `make_stock_adjustment_entry` needs to regenerate the COGS gap line (landed-cost component) on return PIs, making GL regeneration on repost permanently unbalanced — prod case AP-DA1284 (-1.43), which froze the entire repost queue from 2026-06-16. Full postmortem: `paysepar` repo `docs/live/repost-queue-freeze/`.

The snapshot mechanism is self-adjusting (invoice amount + gap = SLE value, for any future revaluation) and is the path external-supplier returns have always used.

## Scope guard (per adversarial verification)

- gate reads `from_warehouse` off the item row directly (NOT `is_internal_transfer()`, which is falsy for inter-company vouchers that DO need the sync)
- `Purchase Receipt Item Supplied` else-branch untouched (old-flow subcontracting)
- unconditional subcontracted `update_valuation_rate` recalc untouched
- 10-scenario matrix verified SAFE (normal+LCV, external return, internal return ±from_warehouse, PR GL path, subcontracting, cancel/amend, inter-company feedback loop)

## Tests

`TestUpdateRateOnPurchaseReceiptGating` (4 mock-based tests, no fixtures) — 4/4 pass:
return w/o from_warehouse never written (PI+PR) · with from_warehouse still synced · external supplier untouched · supplied-item branch untouched.

## Dry run on dev (prod copy)

Repair AP-DA1284 snapshot → `restart_reposting()` → `repost(doc)` → **Completed** (failed hourly for 3 weeks before); GL regenerated identical (AP 25.27 / COGS 1.43 / Inventory 26.70); snapshot survived the repost (no re-clobber).

## Deploy

Ship together with pps190/paysepar#208 (sendmail fix) BEFORE running the prod queue-reset runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)