### PR TITLE
fix: don't re-apply orphan payments already FIFO-allocated by the AR/AP report

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -472,19 +472,28 @@ class ReceivablePayableReport(object):
 			if term.outstanding:
 				self.allocate_closing_to_term(row, term, "credit_note")
 
-		# Fold any orphan-payment allocations (PE refs with NULL payment_term) into the
-		# per-term outstanding via FIFO so the per-term view matches the invoice-level
-		# total. Without this, NULL-term payments only show up in the by-invoice view.
-		from erpnext.accounts.utils import distribute_orphan_payment_to_terms
-
-		distribute_orphan_payment_to_terms(
-			row.voucher_type,
-			row.voucher_no,
-			row.payment_terms,
-			outstanding_key="outstanding",
-			paid_key="paid",
-			due_date_key="due_date",
-		)
+		# Whatever remains in row.paid / row.credit_note is orphan money (PLE-level
+		# payments never booked into Payment Schedule — JE reconciliations, PE refs
+		# with NULL payment_term) that the loop above could not place because its
+		# term already carries a Payment Schedule booking (`if not term.paid` skips
+		# it, since allocate_closing_to_term overwrites rather than adds). Fold that
+		# remainder into terms that still have outstanding, FIFO by due date.
+		# Must work off the in-memory remainder, not a DB-derived orphan total: the
+		# loop above already consumed part (or all) of the orphan money, and only
+		# row.paid knows how much is genuinely left (see #42 — re-deriving from
+		# PLE − Payment Schedule double-counted JE payments).
+		for key in ("paid", "credit_note"):
+			if flt(row[key]) <= 0:
+				continue
+			for term in sorted(row.payment_terms, key=lambda x: x["due_date"]):
+				if flt(row[key]) <= 0:
+					break
+				if flt(term.outstanding) <= 0:
+					continue
+				absorb = min(flt(term.outstanding), flt(row[key]))
+				term[key] = flt(term[key]) + absorb
+				term.outstanding -= absorb
+				row[key] -= absorb
 
 		row.payment_terms = sorted(row.payment_terms, key=lambda x: x["due_date"])
 


### PR DESCRIPTION
Closes #42. Fixes the symptom reported in pps190/notify_contact#51 (AR statement for customer `400200501` short **$7,685.21** vs GL, traced to `AR-DA3969` reconciled by `JE-DA1896`).

## Problem

The AR/AP report ran **two independent orphan-payment allocation passes** on every multi-term invoice:

1. Native pass: builds `row.paid` from PLE (net of Payment Schedule bookings) and FIFO-allocates it across term rows **in memory**, draining `row.paid`.
2. `distribute_orphan_payment_to_terms()` (added `46b39bc678`, broadened `1043f24611`): re-derives the same money **from the DB** as `SUM(PLE) − SUM(Payment Schedule)` and applies it again. It cannot see what pass 1 just allocated, because pass 1 never writes the DB.

For a JE-reconciled invoice (Payment Schedule untouched by JEs), pass 1 allocates everything and pass 2 doubles it exactly.

## Fix

Replace the DB-derived orphan call with distribution of the **in-memory remainder** left in `row.paid` / `row.credit_note` after the native loops — the amount the `if not term.paid` guard couldn't place because a term already carries a Payment Schedule booking. Single pool in and out: each dollar is placed at most once. Genuine overpayment still flows to `allocate_extra_payments_or_credits` unchanged.

`get_split_invoice_rows` / `get_reference_as_per_payment_terms` are untouched — their term view is built purely from Payment Schedule, so the DB-derived orphan fold remains the single, correct pass there (April's AP-DA1255 scenario).

## Verification (dev DB, end-to-end)

Test data: `JE $800 → AR-DA4027` (pure-JE scenario, mirrors prod bug); `PE $1,000 booked to Goods term + JE $500 → AR-DA3966` (April mixed scenario). Report run with the exact filters AR statements use (`party_type`/`party`/`customer`, `based_on_payment_terms=1`).

**Scenario 1 — AR-DA4027, true outstanding $2,575.98:**

| | Goods paid | Goods outst. | Handling outst. | Displayed total |
|---|---|---|---|---|
| before | 1,600.00 (2×800) | 1,585.00 | 190.98 | **1,775.98** ❌ (−$800) |
| after | 800.00 | 2,385.00 | 190.98 | **2,575.98** ✅ |

**Scenario 2 — AR-DA3966, true outstanding $2,988.72:**

| | Goods paid | Goods outst. | Ghost unallocated row | Displayed total |
|---|---|---|---|---|
| before | 1,500.00 (1,000 PS + 500 re-applied) | 2,734.75 | paid 246.03 / outst. −246.03 | **2,488.72** ❌ (−$500) |
| after | 1,246.03 (1,000 PS + 246.03 residual) | 2,988.72 | none | **2,988.72** ✅ |

**PR/PE path (untouched code), same data:** `split_invoices_based_on_payment_terms` returns Goods 2,385.00 + Handling 190.98 = 2,575.98 and Goods 2,734.75 + Handling 253.97 = 2,988.72 — both equal invoice outstanding. ✅

Customer-level report grand total rose by exactly $1,300 (= 800 + 500, the two eliminated double-counts). Test JEs/PE cancelled after verification; invoices restored to original state.

## Post-deploy

Re-run the AR statement for customer `400200501`: `AR-DA3969` should show Goods $78,766.14 + Handling $5,186.96 = $83,953.10, statement total $113,946.70 == GL closing. Then close pps190/notify_contact#51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
