### PR TITLE
fix: skip is_core rows in order qty rollups and rate validation (pps190/next#605)

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -463,8 +463,12 @@ class PurchaseInvoice(BuyingController):
 					"second_join_field": "purchase_order_item",
 					"percent_join_field": "purchase_order",
 					"overflow_type": "receipt",
+					# PPS (pps190/next#605): core deposit rows (is_core=1) never count
+					# toward the order's qty rollup.
 					"extra_cond": """ and exists(select name from `tabPurchase Invoice`
-					where name=`tabPurchase Invoice Item`.parent and update_stock = 1)""",
+					where name=`tabPurchase Invoice Item`.parent and update_stock = 1)
+					and ifnull(`tabPurchase Invoice Item`.is_core, 0) = 0""",
+					"second_source_extra_cond": """ and ifnull(`tabPurchase Receipt Item`.is_core, 0) = 0""",
 				}
 			)
 			if cint(self.is_return):
@@ -480,7 +484,9 @@ class PurchaseInvoice(BuyingController):
 						"second_join_field": "purchase_order_item",
 						"overflow_type": "receipt",
 						"extra_cond": """ and exists (select name from `tabPurchase Invoice`
-						where name=`tabPurchase Invoice Item`.parent and update_stock=1 and is_return=1)""",
+						where name=`tabPurchase Invoice Item`.parent and update_stock=1 and is_return=1)
+						and ifnull(`tabPurchase Invoice Item`.is_core, 0) = 0""",
+						"second_source_extra_cond": """ and ifnull(`tabPurchase Receipt Item`.is_core, 0) = 0""",
 					}
 				)
 

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -434,8 +434,12 @@ class SalesInvoice(SellingController):
 					"second_source_field": "qty",
 					"second_join_field": "so_detail",
 					"overflow_type": "delivery",
+					# PPS (pps190/next#605): core deposit rows (is_core=1) never count
+					# toward the order's qty rollup.
 					"extra_cond": """ and exists(select name from `tabSales Invoice`
-					where name=`tabSales Invoice Item`.parent and update_stock = 1)""",
+					where name=`tabSales Invoice Item`.parent and update_stock = 1)
+					and ifnull(`tabSales Invoice Item`.is_core, 0) = 0""",
+					"second_source_extra_cond": """ and ifnull(`tabDelivery Note Item`.is_core, 0) = 0""",
 				}
 			)
 			if cint(self.is_return):
@@ -450,7 +454,9 @@ class SalesInvoice(SellingController):
 						"second_source_dt": "Delivery Note Item",
 						"second_source_field": "-1 * qty",
 						"second_join_field": "so_detail",
-						"extra_cond": """ and exists (select name from `tabSales Invoice` where name=`tabSales Invoice Item`.parent and update_stock=1 and is_return=1)""",
+						"extra_cond": """ and exists (select name from `tabSales Invoice` where name=`tabSales Invoice Item`.parent and update_stock=1 and is_return=1)
+						and ifnull(`tabSales Invoice Item`.is_core, 0) = 0""",
+						"second_source_extra_cond": """ and ifnull(`tabDelivery Note Item`.is_core, 0) = 0""",
 					}
 				)
 

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -22,6 +22,9 @@ class DeliveryNote(SellingController):
 	def __init__(self, *args, **kwargs):
 		super(DeliveryNote, self).__init__(*args, **kwargs)
 		self.status_updater = [
+			# PPS (pps190/next#605): core deposit rows (is_core=1, custom field from the
+			# `next` app) carry so_detail for billing but must never count toward the
+			# order's qty rollup — hence the is_core filters on every qty source below.
 			{
 				"source_dt": "Delivery Note Item",
 				"target_dt": "Sales Order Item",
@@ -38,8 +41,10 @@ class DeliveryNote(SellingController):
 				"second_source_field": "qty",
 				"second_join_field": "so_detail",
 				"overflow_type": "delivery",
+				"extra_cond": """ and ifnull(`tabDelivery Note Item`.is_core, 0) = 0""",
 				"second_source_extra_cond": """ and exists(select name from `tabSales Invoice`
-				where name=`tabSales Invoice Item`.parent and update_stock = 1)""",
+				where name=`tabSales Invoice Item`.parent and update_stock = 1)
+				and ifnull(`tabSales Invoice Item`.is_core, 0) = 0""",
 			},
 			{
 				"source_dt": "Delivery Note Item",
@@ -68,9 +73,11 @@ class DeliveryNote(SellingController):
 						"second_source_field": "-1 * qty",
 						"second_join_field": "so_detail",
 						"extra_cond": """ and exists (select name from `tabDelivery Note`
-					where name=`tabDelivery Note Item`.parent and is_return=1)""",
+					where name=`tabDelivery Note Item`.parent and is_return=1)
+					and ifnull(`tabDelivery Note Item`.is_core, 0) = 0""",
 						"second_source_extra_cond": """ and exists (select name from `tabSales Invoice`
-					where name=`tabSales Invoice Item`.parent and is_return=1 and update_stock=1)""",
+					where name=`tabSales Invoice Item`.parent and is_return=1 and update_stock=1)
+					and ifnull(`tabSales Invoice Item`.is_core, 0) = 0""",
 					},
 					{
 						"source_dt": "Delivery Note Item",

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -24,6 +24,9 @@ class PurchaseReceipt(BuyingController):
 	def __init__(self, *args, **kwargs):
 		super(PurchaseReceipt, self).__init__(*args, **kwargs)
 		self.status_updater = [
+			# PPS (pps190/next#605): core deposit rows (is_core=1, custom field from the
+			# `next` app) carry purchase_order_item for structural uniformity but must
+			# never count toward the order's qty rollup — hence the is_core filters.
 			{
 				"target_dt": "Purchase Order Item",
 				"join_field": "purchase_order_item",
@@ -38,8 +41,10 @@ class PurchaseReceipt(BuyingController):
 				"second_join_field": "po_detail",
 				"percent_join_field": "purchase_order",
 				"overflow_type": "receipt",
+				"extra_cond": """ and ifnull(`tabPurchase Receipt Item`.is_core, 0) = 0""",
 				"second_source_extra_cond": """ and exists(select name from `tabPurchase Invoice`
-				where name=`tabPurchase Invoice Item`.parent and update_stock = 1)""",
+				where name=`tabPurchase Invoice Item`.parent and update_stock = 1)
+				and ifnull(`tabPurchase Invoice Item`.is_core, 0) = 0""",
 			},
 			{
 				"source_dt": "Purchase Receipt Item",
@@ -89,9 +94,11 @@ class PurchaseReceipt(BuyingController):
 						"second_source_field": "-1 * qty",
 						"second_join_field": "po_detail",
 						"extra_cond": """ and exists (select name from `tabPurchase Receipt`
-						where name=`tabPurchase Receipt Item`.parent and is_return=1)""",
+						where name=`tabPurchase Receipt Item`.parent and is_return=1)
+						and ifnull(`tabPurchase Receipt Item`.is_core, 0) = 0""",
 						"second_source_extra_cond": """ and exists (select name from `tabPurchase Invoice`
-						where name=`tabPurchase Invoice Item`.parent and is_return=1 and update_stock=1)""",
+						where name=`tabPurchase Invoice Item`.parent and is_return=1 and update_stock=1)
+						and ifnull(`tabPurchase Invoice Item`.is_core, 0) = 0""",
 					},
 					{
 						"source_dt": "Purchase Receipt Item",

--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -102,6 +102,11 @@ class TransactionBase(StatusUpdater):
 			reference_names = [d.get(ref_link_field) for d in self.get("items") if d.get(ref_link_field)]
 			reference_details = self.get_reference_details(reference_names, ref_dt + " Item")
 			for d in self.get("items"):
+				# PPS (pps190/next#605): core deposit rows reference the order's
+				# part line for billing, but their rate is the deposit rate — by
+				# design different from the part line's (which folds the core in).
+				if d.get("is_core"):
+					continue
 				if d.get(ref_link_field):
 					ref_rate = reference_details.get(d.get(ref_link_field))
 


### PR DESCRIPTION
Companion to pps190/next#605 (core deposit rows never bill back — orders stuck < 100%, DN/PR stuck "To Bill").

The `next` app's fix makes core rows first-class: they carry `so_detail` / `purchase_order_item` / `po_detail` like part rows so their **amounts** bill back natively. This PR is the qty-side guarantee: **core rows never count toward an order's delivered/received/returned quantity rollup.**

## Changes

`and ifnull(is_core, 0) = 0` appended to the qty-rollup conditions whose **target is a master order line** — 8 status_updater entries / 16 condition strings, each marked `PPS (pps190/next#605)`:

| File | Entries |
|---|---|
| `delivery_note.py` | DN→SO `delivered_qty` (new `extra_cond` + SI second source), DN→SO `returned_qty` (+ second source) |
| `purchase_receipt.py` | PR→PO `received_qty` (new `extra_cond` + PI second source), PR→PO `returned_qty` (+ second source) |
| `sales_invoice.py` | update_stock SI→SO `delivered_qty` (+ new DN second-source cond), returned (+ second source) |
| `purchase_invoice.py` | update_stock PI→PO `received_qty` (+ new PR second-source cond), returned (+ second source) |

Deliberately **not** filtered (core-to-core 1:1 by design): DN→SI via `si_detail`, PR→PI via `purchase_invoice_item`, per_returned entries — these target the sibling core row itself, which is how PI `per_received` reaches 100%.

Plus one validation skip: `transaction_base.py` `validate_rate_with_reference_doc` ignores `is_core` rows — a core row references the order's part line for billing, but its rate is the deposit rate, by design different from the part line's folded rate (with Buying/Selling Settings `maintain_same_rate = Stop` the check would otherwise block every core-carrying PI/SI).

`validate_qty` needs no change: it reads the stored target values, which the filtered SUMs write.

## Notes

- **This fork is now permanently bound to the `next` app**: `is_core` is a `next` custom column; a bare-erpnext site would fail on invoice submit. Same class of fork patch as the handling-fee changes — re-apply on version merges.
- Zero impact on existing data until core rows start carrying master refs (they never did before the `next` PR): the filters exclude rows that don't exist yet, and the `next` backfill relies on these filters being live — **merge/deploy this first or together**.
- Verified by `next/tests/test_core_billing_refs.py` (notably `test_update_stock_invoice_core_billed_qty_safe`, which exercises these conditions directly: SO billed 100%, delivered ×3 not ×6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
