### PR TITLE
feat: allow on-account Receive-from-Supplier Payment Entry with submit confirmation

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -1453,6 +1453,25 @@ frappe.ui.form.on('Payment Entry Deduction', {
 	}
 })
 frappe.ui.form.on('Payment Entry', {
+	before_submit: function(frm) {
+		if (
+			frm.doc.payment_type === "Receive" &&
+			frm.doc.party_type === "Supplier" &&
+			!(frm.doc.references || []).some((r) => flt(r.outstanding_amount) < 0)
+		) {
+			return new Promise((resolve, reject) => {
+				frappe.confirm(
+					__(
+						"You are recording money <b>received from Supplier {0}</b>: the bank account will increase and the amount owed to this supplier will <b>increase</b> by {1}.<br><br>If you meant to <b>pay</b> this supplier, click No and change Payment Type to Pay.",
+						[frm.doc.party_name || frm.doc.party, format_currency(frm.doc.paid_amount, frm.doc.paid_from_account_currency)]
+					),
+					() => resolve(),
+					() => reject()
+				);
+			});
+		}
+	},
+
 	cost_center: function(frm){
 		if (frm.doc.posting_date && (frm.doc.paid_from||frm.doc.paid_to)) {
 			return frappe.call({

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -928,6 +928,18 @@ class PaymentEntry(AccountsController):
 		):
 			return
 
+		# On-account receipt from a supplier (e.g. CARM duty refunds) has no
+		# invoice to reference; direction is confirmed client-side before submit.
+		if self.payment_type == "Receive" and self.party_type == "Supplier" and not self.get("references"):
+			frappe.msgprint(
+				_(
+					"No references selected: this records an on-account receipt from Supplier {0} and increases the payable balance by {1}."
+				).format(self.party, fmt_money(self.paid_amount, currency=self.paid_from_account_currency)),
+				indicator="orange",
+				alert=True,
+			)
+			return
+
 		total_negative_outstanding = flt(
 			sum(
 				abs(flt(d.outstanding_amount)) for d in self.get("references") if flt(d.outstanding_amount) < 0


### PR DESCRIPTION
Receive+Supplier with no references (e.g. CARM duty refunds) was hard-blocked by `validate_payment_against_negative_invoice` even though no negative outstanding invoice can exist for JE-only supplier accounts (500200201 Canada Custom CARM has zero Purchase Invoices — its entire ledger is Journal Entries and Payment Entries).

**Server** (`payment_entry.py`): relax only the empty-references case for Receive+Supplier, with an orange msgprint noting the payable will increase. Pay+Customer stays blocked, positive-only references stay blocked, and the overpay cap against negative outstanding stays intact.

**Client** (`payment_entry.js`): new `before_submit` confirm dialog when a Receive+Supplier PE has no negative-outstanding reference — states that bank increases and payable increases, and to use Pay if the user meant to pay. Clicking No aborts submit. This preserves the typo-protection the hard block used to provide.

Verified locally: 4-case validation sanity check (allowed / still-blocked matrix) and a headed Playwright run confirming the dialog renders and No keeps the doc in Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)