### PR TITLE
fix: skip client-side negative-outstanding warning for on-account Receive-from-Supplier

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -846,6 +846,15 @@ frappe.ui.form.on('Payment Entry', {
 			total_negative_outstanding = flt(total_negative_outstanding, precision("outstanding_amount"))
 			if(paid_amount > total_negative_outstanding) {
 				if(total_negative_outstanding == 0) {
+					// On-account Receive-from-Supplier with no references is allowed
+					// (relaxed server-side); nothing to allocate, so skip the warning.
+					if (
+						frm.doc.payment_type == "Receive" &&
+						frm.doc.party_type == "Supplier" &&
+						!(frm.doc.references || []).length
+					) {
+						return false;
+					}
 					frappe.msgprint(
 						__("Cannot {0} {1} {2} without any negative outstanding invoice", [frm.doc.payment_type,
 							(frm.doc.party_type=="Customer" ? "to" : "from"), frm.doc.party_type])


### PR DESCRIPTION
Follow-up to #45. `allocate_party_amount_against_ref_docs` in `payment_entry.js` pops the same "Cannot Receive from Supplier without any negative outstanding invoice" msgprint the moment a paid amount is entered, independent of the (now relaxed) server validation. Mirror the server rule: skip the warning when a Receive+Supplier entry has no references at all — there is nothing to allocate. The warning still fires for Pay+Customer and whenever references exist.

Verified headed with Playwright: setting paid_amount on a no-references Receive-from-Supplier draft no longer shows the msgprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)