### PR TITLE
fix: credit the payable for unallocated on-account Receive-from-Supplier amounts

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1100,10 +1100,16 @@ class PaymentEntry(AccountsController):
 
 				gle = party_gl_dict.copy()
 
+				# dr_or_cr above follows the party account type only; an on-account
+				# receipt from a supplier must credit the payable instead.
+				row_dr_or_cr = dr_or_cr
+				if self.payment_type == "Receive" and self.party_type == "Supplier":
+					row_dr_or_cr = "credit"
+
 				gle.update(
 					{
-						dr_or_cr + "_in_account_currency": self.unallocated_amount,
-						dr_or_cr: base_unallocated_amount,
+						row_dr_or_cr + "_in_account_currency": self.unallocated_amount,
+						row_dr_or_cr: base_unallocated_amount,
 					}
 				)
 


### PR DESCRIPTION
Follow-up to #45/#46 — fixes the submit failure `Debit and Credit not equal for Payment Entry. Difference is 214.0`.

`add_party_gl_entries` derives `dr_or_cr` from the party account type alone (Payable → debit), so an on-account Receive-from-Supplier posted its unallocated amount as a **debit** on AP alongside the bank debit — both sides debit, GL unbalanced by 2× paid amount. Flip only the **unallocated row** to credit for Receive+Supplier. Reference rows (which rely on negative allocated amounts sign-flipping in `process_gl_map`) and all Pay flows are untouched.

Verified locally with a full submit round-trip (paid 107):
- GL: `21111 AP` credit 107 (party set) / `11108 CIBC` debit 107 — balanced, submit succeeds
- Payment Ledger Entry: +107 on the payable — on-account receipt correctly increases the supplier balance
- Test PE cancelled + deleted afterwards

Not merging this one myself — please review and approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)