### PR TITLE
feat: allow Payment Entry as a reference doctype for Customer/Supplier payments

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -107,9 +107,9 @@ frappe.ui.form.on('Payment Entry', {
 
 		frm.set_query("reference_doctype", "references", function() {
 			if (frm.doc.party_type == "Customer") {
-				var doctypes = ["Sales Order", "Sales Invoice", "Journal Entry", "Dunning"];
+				var doctypes = ["Sales Order", "Sales Invoice", "Journal Entry", "Dunning", "Payment Entry"];
 			} else if (frm.doc.party_type == "Supplier") {
-				var doctypes = ["Purchase Order", "Purchase Invoice", "Journal Entry"];
+				var doctypes = ["Purchase Order", "Purchase Invoice", "Journal Entry", "Payment Entry"];
 			} else {
 				var doctypes = ["Journal Entry"];
 			}
@@ -139,6 +139,9 @@ frappe.ui.form.on('Payment Entry', {
 
 			if (in_list(party_type_doctypes, child.reference_doctype)) {
 				filters[doc.party_type.toLowerCase()] = doc.party;
+			} else if (child.reference_doctype === "Payment Entry") {
+				filters["party_type"] = doc.party_type;
+				filters["party"] = doc.party;
 			}
 
 			return {
@@ -986,18 +989,18 @@ frappe.ui.form.on('Payment Entry', {
 			}
 
 			if(frm.doc.party_type=="Customer" &&
-				!in_list(["Sales Order", "Sales Invoice", "Journal Entry", "Dunning"], row.reference_doctype)
+				!in_list(["Sales Order", "Sales Invoice", "Journal Entry", "Dunning", "Payment Entry"], row.reference_doctype)
 			) {
 				frappe.model.set_value(row.doctype, row.name, "reference_doctype", null);
-				frappe.msgprint(__("Row #{0}: Reference Document Type must be one of Sales Order, Sales Invoice, Journal Entry or Dunning", [row.idx]));
+				frappe.msgprint(__("Row #{0}: Reference Document Type must be one of Sales Order, Sales Invoice, Journal Entry, Dunning or Payment Entry", [row.idx]));
 				return false;
 			}
 
 			if(frm.doc.party_type=="Supplier" &&
-				!in_list(["Purchase Order", "Purchase Invoice", "Journal Entry"], row.reference_doctype)
+				!in_list(["Purchase Order", "Purchase Invoice", "Journal Entry", "Payment Entry"], row.reference_doctype)
 			) {
 				frappe.model.set_value(row.doctype, row.name, "against_voucher_type", null);
-				frappe.msgprint(__("Row #{0}: Reference Document Type must be one of Purchase Order, Purchase Invoice or Journal Entry", [row.idx]));
+				frappe.msgprint(__("Row #{0}: Reference Document Type must be one of Purchase Order, Purchase Invoice, Journal Entry or Payment Entry", [row.idx]));
 				return false;
 			}
 		}

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -428,7 +428,7 @@ class PaymentEntry(AccountsController):
 			if d.reference_doctype not in valid_reference_doctypes:
 				frappe.throw(
 					_("Reference Doctype must be one of {0}").format(
-						comma_or((_(d) for d in valid_reference_doctypes))
+						comma_or([_(v) for v in valid_reference_doctypes])
 					)
 				)
 
@@ -438,7 +438,14 @@ class PaymentEntry(AccountsController):
 				else:
 					ref_doc = frappe.get_doc(d.reference_doctype, d.reference_name)
 
-					if d.reference_doctype != "Journal Entry":
+					if d.reference_doctype == "Payment Entry":
+						if ref_doc.party_type != self.party_type or ref_doc.party != self.party:
+							frappe.throw(
+								_("{0} {1} is not associated with {2} {3}").format(
+									_(d.reference_doctype), d.reference_name, _(self.party_type), self.party
+								)
+							)
+					elif d.reference_doctype != "Journal Entry":
 						if self.party != ref_doc.get(scrub(self.party_type)):
 							frappe.throw(
 								_("{0} {1} is not associated with {2} {3}").format(
@@ -476,9 +483,9 @@ class PaymentEntry(AccountsController):
 
 	def get_valid_reference_doctypes(self):
 		if self.party_type == "Customer":
-			return ("Sales Order", "Sales Invoice", "Journal Entry", "Dunning")
+			return ("Sales Order", "Sales Invoice", "Journal Entry", "Dunning", "Payment Entry")
 		elif self.party_type == "Supplier":
-			return ("Purchase Order", "Purchase Invoice", "Journal Entry")
+			return ("Purchase Order", "Purchase Invoice", "Journal Entry", "Payment Entry")
 		elif self.party_type == "Shareholder":
 			return ("Journal Entry",)
 		elif self.party_type == "Employee":
@@ -1983,6 +1990,23 @@ def get_reference_details(reference_doctype, reference_name, party_account_curre
 		else:
 			exchange_rate = 1
 			outstanding_amount = get_outstanding_on_journal_entry(reference_name)
+
+	elif reference_doctype == "Payment Entry":
+		# e.g. an on-account Receive-from-Supplier leaves a positive residual
+		# on the payable; the payment ledger holds its live outstanding.
+		total_amount = flt(
+			ref_doc.get("paid_amount")
+			if ref_doc.get("payment_type") == "Receive"
+			else ref_doc.get("received_amount")
+		)
+		exchange_rate = flt(ref_doc.get("source_exchange_rate")) or 1
+		outstanding_amount = flt(
+			frappe.db.get_value(
+				"Payment Ledger Entry",
+				{"voucher_type": "Payment Entry", "voucher_no": reference_name, "delinked": 0},
+				"sum(amount)",
+			)
+		)
 
 	elif reference_doctype != "Journal Entry":
 		if not total_amount:

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -439,11 +439,36 @@ class PaymentEntry(AccountsController):
 					ref_doc = frappe.get_doc(d.reference_doctype, d.reference_name)
 
 					if d.reference_doctype == "Payment Entry":
+						if d.reference_name == self.name:
+							frappe.throw(
+								_("Row #{0}: A Payment Entry cannot reference itself").format(d.idx)
+							)
 						if ref_doc.party_type != self.party_type or ref_doc.party != self.party:
 							frappe.throw(
 								_("{0} {1} is not associated with {2} {3}").format(
 									_(d.reference_doctype), d.reference_name, _(self.party_type), self.party
 								)
+							)
+						# Only invoice-direction residuals (positive net in the payment
+						# ledger, e.g. an on-account receipt from a supplier) may be
+						# settled by reference. Advance credits (negative net) are
+						# handled through Payment Reconciliation instead.
+						ple_net = flt(
+							frappe.db.get_value(
+								"Payment Ledger Entry",
+								{
+									"voucher_type": "Payment Entry",
+									"voucher_no": d.reference_name,
+									"delinked": 0,
+								},
+								"sum(amount)",
+							)
+						)
+						if ple_net <= 0:
+							frappe.throw(
+								_(
+									"Row #{0}: {1} has no positive outstanding balance. Advance credits are settled via Payment Reconciliation, not as a Payment Entry reference."
+								).format(d.idx, d.reference_name)
 							)
 					elif d.reference_doctype != "Journal Entry":
 						if self.party != ref_doc.get(scrub(self.party_type)):

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -1331,6 +1331,93 @@ class TestPaymentEntry(FrappeTestCase):
 		expected_out_str = json.dumps(sorted(expected_pl_entries, key=json.dumps))
 		self.assertEqual(out_str, expected_out_str)
 
+	def test_on_account_receive_from_supplier(self):
+		"""Receive+Supplier with no references posts bank debit / payable credit."""
+		pe = create_payment_entry(
+			payment_type="Receive",
+			party_type="Supplier",
+			party="_Test Supplier",
+			paid_from="Creditors - _TC",
+			paid_to="_Test Bank - _TC",
+			paid_amount=100,
+			save=True,
+			submit=True,
+		)
+
+		expected_gle = dict(
+			(d[0], d)
+			for d in [["Creditors - _TC", 0, 100, None], ["_Test Bank - _TC", 100, 0, None]]
+		)
+		self.validate_gl_entries(pe.name, expected_gle)
+
+		self.assertPLEntries(pe, [{"amount": 100.0, "against_voucher_no": pe.name}])
+		pe.cancel()
+
+	def test_pay_against_on_account_receive_pe(self):
+		"""A Pay PE can reference a positive-residual Payment Entry and net it out."""
+		receive_pe = create_payment_entry(
+			payment_type="Receive",
+			party_type="Supplier",
+			party="_Test Supplier",
+			paid_from="Creditors - _TC",
+			paid_to="_Test Bank - _TC",
+			paid_amount=100,
+			save=True,
+			submit=True,
+		)
+
+		pay_pe = create_payment_entry(paid_amount=100)
+		pay_pe.append(
+			"references",
+			{
+				"reference_doctype": "Payment Entry",
+				"reference_name": receive_pe.name,
+				"allocated_amount": 100,
+			},
+		)
+		pay_pe.save()
+		pay_pe.submit()
+
+		self.assertPLEntries(pay_pe, [{"amount": -100.0, "against_voucher_no": receive_pe.name}])
+		residual = frappe.db.get_value(
+			"Payment Ledger Entry",
+			{"against_voucher_no": receive_pe.name, "delinked": 0},
+			"sum(amount)",
+		)
+		self.assertEqual(flt(residual), 0.0)
+
+		pay_pe.cancel()
+		receive_pe.cancel()
+
+	def test_pe_reference_guards(self):
+		"""Self-references and advance (negative-residual) PE references are blocked."""
+		# advance: unallocated Pay -> negative net in the payment ledger
+		advance_pe = create_payment_entry(paid_amount=50, save=True, submit=True)
+
+		pay_pe = create_payment_entry(paid_amount=10)
+		pay_pe.append(
+			"references",
+			{
+				"reference_doctype": "Payment Entry",
+				"reference_name": advance_pe.name,
+				"allocated_amount": -10,
+			},
+		)
+		self.assertRaises(frappe.ValidationError, pay_pe.save)
+
+		self_pe = create_payment_entry(paid_amount=10, save=True)
+		self_pe.append(
+			"references",
+			{
+				"reference_doctype": "Payment Entry",
+				"reference_name": self_pe.name,
+				"allocated_amount": 10,
+			},
+		)
+		self.assertRaises(frappe.ValidationError, self_pe.save)
+
+		advance_pe.cancel()
+
 
 def create_payment_entry(**args):
 	payment_entry = frappe.new_doc("Payment Entry")


### PR DESCRIPTION
Follow-up to #45–#47. An on-account Receive-from-Supplier (e.g. PE-DA1981-1, the CARM refund) leaves a **positive residual on the payable** that `get_outstanding_invoices` lists in Get Outstanding, but `validate_reference_documents` rejected `Payment Entry` as a reference type — so the residual could never be settled, neither from a Pay PE nor via Payment Reconciliation (which writes references through the same validation). This is the `Reference Doctype must be one of <generator …>` error.

- `get_valid_reference_doctypes`: add **Payment Entry** for Customer/Supplier
- `validate_reference_documents`: match PE refs on `party_type`/`party` (PE has no scrubbed party fieldname), and fix the garbled message (a generator was passed to `comma_or`, rendering as `<generator object …>` that the browser swallowed as an HTML tag)
- `get_reference_details`: resolve a PE reference's outstanding from the Payment Ledger
- `payment_entry.js`: extend reference doctype/name queries + client-side whitelist to match

**Note:** `next` must be updated in the same deploy — its `NextPaymentEntry` inherits hrms's `EmployeePaymentEntry`, which re-hardcodes the old list and shadows this change. Companion PR: pps190/next (`fix/pe-reference-doctype-override`).

Verified locally end-to-end: Pay PE referencing the on-account receive PE submits with balanced GL (`against_voucher` set), Payment Ledger nets the receive PE to zero and it drops out of Get Outstanding; cancelling restores it. Headed Playwright confirms the UI save path keeps the reference row.

Not merging myself — please review and approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)