### PR TITLE
fix(regional): UAE itemised tax crash on cart rows with no item_code

### DIFF
--- a/erpnext/regional/united_arab_emirates/utils.py
+++ b/erpnext/regional/united_arab_emirates/utils.py
@@ -25,7 +25,7 @@ def update_itemised_tax_data(doc):
 		# dont even bother checking in item tax template as it contains both input and output accounts - double the tax rate
 		item_code = row.item_code or row.item_name
 		if itemised_tax.get(item_code):
-			for tax in itemised_tax.get(row.item_code).values():
+			for tax in itemised_tax.get(item_code, {}).values():
 				_tax_rate = flt(tax.get("tax_rate", 0), row.precision("tax_rate"))
 				tax_amount += flt((row.net_amount * _tax_rate) / 100, row.precision("tax_amount"))
 				tax_rate += _tax_rate


### PR DESCRIPTION
Closes #50

## Problem

Place Order on any **UAE-company** cart containing a row whose part number is not in the Item master yet (`item_code = NULL`, part number in `item_name`) failed with:

```
File "erpnext/regional/united_arab_emirates/utils.py", line 28, in update_itemised_tax_data
    for tax in itemised_tax.get(row.item_code).values():
AttributeError: 'NoneType' object has no attribute 'values'
```

`update_itemised_tax_data` builds its guard key as `row.item_code or row.item_name` (line 26) but fetched with `row.item_code` alone (line 28). The itemised tax detail is keyed by `item.item_code or item.item_name` (`set_item_wise_tax`, `controllers/taxes_and_totals.py:494`), so for a NULL-item_code row the guard passes via `item_name` while the fetch uses `None` → `None.values()`.

Only UAE-company documents hit this because `get_itemised_tax_breakup_html` selects the regional override from the **document company** via `temporary_flag("company", doc.company)` — which is why the failure looked user-specific in the field (it tracks the cart's company, not the logged-in user).

## Fix

Fetch with the already-computed fallback key and a safe default (upstream's `.get(..., {})` style):

```python
for tax in itemised_tax.get(item_code, {}).values():
```

Side benefit: not-yet-catalogued rows now actually get their 5% VAT rate/amount on the item row instead of being skipped.

## Verification

Reproduced locally on QTN-72572 (submitted UAE-company Proforma, 10 NULL-item_code rows, VAT Q3 5%): `make_sales_order` crashed with the exact production traceback before the fix; after the fix it completes and every previously-crashing row carries `tax_rate 5.0` with the correct `tax_amount`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)