### PR TITLE
fix(landed-cost): post the reconciled charge share to the GL

### DIFF
--- a/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
@@ -410,6 +410,159 @@ class TestLandedCostVoucher(FrappeTestCase):
 		self.assertEqual(flt(lcv.items[0].applicable_charges, 2), 41.07)
 		self.assertEqual(flt(lcv.items[2].applicable_charges, 2), 41.08)
 
+	def test_gl_entries_match_reconciled_applicable_charges(self):
+		"""PPS (pps190/next#721): the charges credited to the clearing account must add up
+		to the charges the voucher reconciled, to the cent.
+
+		The voucher rounds each item's share and pushes the remainder onto the last row,
+		so 10.00 over three equal receipts becomes 3.33 / 3.33 / 3.34. The GL used to
+		re-derive each share as a raw float instead of reading that reconciled figure,
+		posting 3.33 three times and stranding a cent in the clearing account.
+
+		Three *separate* receipts matter: a single receipt merges its same-account rows
+		before writing the GL, which hides the per-slice rounding.
+		"""
+		prs = [self._make_single_item_receipt(rate=1, qty=1) for _ in range(3)]
+
+		lcv = self._make_lcv_over_receipts(prs, charges=10)
+
+		# The voucher itself reconciles — the last row absorbs the remainder.
+		self.assertEqual([flt(d.applicable_charges, 2) for d in lcv.items], [3.33, 3.33, 3.34])
+
+		rows = self._get_charge_gl_entries(prs, "Expenses Included In Valuation - TCP1")
+		self.assertEqual(len(rows), 3)
+
+		# The clearing account is credited the whole charge — no stranded cent.
+		self.assertEqual(flt(sum(flt(d.credit) for d in rows), 2), 10.00)
+		self.assertEqual(sorted(flt(d.credit, 2) for d in rows), [3.33, 3.33, 3.34])
+
+		# The account-currency column is rounded too, so it agrees with `credit` row by
+		# row. It used to receive the raw 3.333333333 while `credit` was rounded on write.
+		for gle in rows:
+			self.assertEqual(flt(gle.credit, 2), flt(gle.credit_in_account_currency, 2))
+			self.assertEqual(
+				flt(gle.credit_in_account_currency), flt(gle.credit_in_account_currency, 2)
+			)
+
+	def test_gl_entries_split_across_multiple_charge_accounts(self):
+		"""With more than one charge row the reconciled share is apportioned between the
+		accounts; each posted amount is still rounded, and the accounts together still
+		carry the full charge."""
+		insurance = create_account(
+			account_name="_Test LCV Insurance 721",
+			parent_account="Duties and Taxes - TCP1",
+			company="_Test Company with perpetual inventory",
+		)
+
+		prs = [self._make_single_item_receipt(rate=1, qty=1) for _ in range(3)]
+
+		lcv = self._make_lcv_over_receipts(prs, charges=10, do_not_submit=True)
+		lcv.append(
+			"taxes",
+			{"description": "Insurance Charges", "expense_account": insurance, "amount": 3.22},
+		)
+		lcv.save()
+		lcv.submit()
+
+		self.assertEqual(flt(lcv.total_taxes_and_charges, 2), 13.22)
+
+		rows = self._get_charge_gl_entries(
+			prs, ["Expenses Included In Valuation - TCP1", insurance]
+		)
+		self.assertTrue(rows)
+
+		# Nothing posted as a raw float.
+		for gle in rows:
+			self.assertEqual(flt(gle.credit), flt(gle.credit, 2))
+			self.assertEqual(
+				flt(gle.credit_in_account_currency), flt(gle.credit_in_account_currency, 2)
+			)
+
+		# Both charge accounts together carry the whole charge.
+		self.assertEqual(flt(sum(flt(d.credit) for d in rows), 2), 13.22)
+
+	def test_gl_entries_follow_manually_distributed_charges(self):
+		"""Under "Distribute Manually" the GL must credit the split the user typed.
+
+		The old GL path apportioned by each item's `amount` regardless of the mode, so a
+		deliberately uneven manual split was posted evenly — the voucher and the ledger
+		disagreed even though nothing needed rounding.
+		"""
+		prs = [self._make_single_item_receipt(rate=100, qty=1) for _ in range(2)]
+
+		lcv = self._make_lcv_over_receipts(
+			prs, charges=100, distribute_charges_based_on="Distribute Manually", do_not_submit=True
+		)
+		lcv.get_items_from_purchase_receipts()
+		lcv.items[0].applicable_charges = 90
+		lcv.items[1].applicable_charges = 10
+		lcv.save()
+		lcv.submit()
+
+		rows = self._get_charge_gl_entries(prs, "Expenses Included In Valuation - TCP1")
+		self.assertEqual(sorted(flt(d.credit, 2) for d in rows), [10.00, 90.00])
+		self.assertEqual(flt(sum(flt(d.credit) for d in rows), 2), 100.00)
+
+	def _make_single_item_receipt(self, rate, qty):
+		pr = make_purchase_receipt(
+			company="_Test Company with perpetual inventory",
+			warehouse="Stores - TCP1",
+			supplier_warehouse="Work In Progress - TCP1",
+			qty=qty,
+			rate=rate,
+			do_not_save=True,
+		)
+		pr.items[0].cost_center = "Main - TCP1"
+		pr.submit()
+		return pr
+
+	def _make_lcv_over_receipts(
+		self, prs, charges, do_not_submit=False, distribute_charges_based_on="Amount"
+	):
+		lcv = frappe.new_doc("Landed Cost Voucher")
+		lcv.company = prs[0].company
+		lcv.distribute_charges_based_on = distribute_charges_based_on
+
+		for pr in prs:
+			lcv.append(
+				"purchase_receipts",
+				{
+					"receipt_document_type": "Purchase Receipt",
+					"receipt_document": pr.name,
+					"supplier": pr.supplier,
+					"posting_date": pr.posting_date,
+					"grand_total": pr.base_grand_total,
+				},
+			)
+
+		lcv.append(
+			"taxes",
+			{
+				"description": "Insurance Charges",
+				"expense_account": "Expenses Included In Valuation - TCP1",
+				"amount": charges,
+			},
+		)
+
+		lcv.insert()
+		if not do_not_submit:
+			lcv.submit()
+		return lcv
+
+	def _get_charge_gl_entries(self, prs, accounts):
+		if isinstance(accounts, str):
+			accounts = [accounts]
+		return frappe.get_all(
+			"GL Entry",
+			fields=["voucher_no", "account", "credit", "credit_in_account_currency"],
+			filters={
+				"voucher_type": "Purchase Receipt",
+				"voucher_no": ("in", [pr.name for pr in prs]),
+				"account": ("in", accounts),
+				"is_cancelled": 0,
+			},
+		)
+
 	def test_multiple_landed_cost_voucher_against_pr(self):
 		pr = make_purchase_receipt(
 			company="_Test Company with perpetual inventory",

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -6,6 +6,7 @@ import frappe
 from frappe import _, throw
 from frappe.desk.notifications import clear_doctype_notifications
 from frappe.model.mapper import get_mapped_doc
+from frappe.model.meta import get_field_precision
 from frappe.query_builder.functions import CombineDatetime
 from frappe.utils import cint, flt, getdate, nowdate
 from pypika import functions as fn
@@ -458,7 +459,17 @@ class PurchaseReceipt(BuyingController):
 							credit=credit_amount,
 							remarks=remarks,
 							against_account=stock_asset_account_name,
-							credit_in_account_currency=flt(amount["amount"]),
+							# PPS (pps190/next#721): round to the account's own currency
+							# precision. This column used to receive the raw float while
+							# `credit` was rounded on write, so the two disagreed on every
+							# row even at exchange rate 1.
+							credit_in_account_currency=flt(
+								amount["amount"],
+								get_field_precision(
+									frappe.get_meta("GL Entry").get_field("credit_in_account_currency"),
+									currency=account_currency,
+								),
+							),
 							account_currency=account_currency,
 							project=item.project,
 							item=item,
@@ -1164,46 +1175,87 @@ def get_item_account_wise_additional_cost(purchase_document):
 	for lcv in landed_cost_vouchers:
 		landed_cost_voucher_doc = frappe.get_doc("Landed Cost Voucher", lcv.parent)
 
-		# Use amount field for total item cost for manually cost distributed LCVs
-		if landed_cost_voucher_doc.distribute_charges_based_on == "Distribute Manually":
-			based_on_field = "amount"
-		else:
-			based_on_field = frappe.scrub(landed_cost_voucher_doc.distribute_charges_based_on)
-
-		total_item_cost = 0
-
 		for item in landed_cost_voucher_doc.items:
-			total_item_cost += item.get(based_on_field)
+			if item.receipt_document != purchase_document:
+				continue
 
-		for item in landed_cost_voucher_doc.items:
-			if item.receipt_document == purchase_document:
-				for account in landed_cost_voucher_doc.taxes:
-					item_account_wise_cost.setdefault((item.item_code, item.purchase_receipt_item), {})
-					item_account_wise_cost[(item.item_code, item.purchase_receipt_item)].setdefault(
-						account.expense_account, {"amount": 0.0, "base_amount": 0.0}
-					)
+			# PPS (pps190/next#721): post the *reconciled* share, not a fresh unrounded
+			# one. `applicable_charges` is what the LCV rounded to field precision and
+			# then balanced (the last row absorbs the remainder), so it sums exactly to
+			# `total_taxes_and_charges` and is what drives stock valuation. Recomputing
+			# `account.amount * based_on / total_item_cost` here re-derived the share as a
+			# raw float, so the GL never saw that remainder and the landed-cost clearing
+			# account was left holding cents that only a manual write-off could clear.
+			#
+			# Reading the reconciled figure also fixes "Distribute Manually": the old
+			# code apportioned by the item's `amount` even in that mode, so the GL
+			# ignored the split the user had actually typed.
+			for account, amount, base_amount in split_applicable_charges_by_account(
+				landed_cost_voucher_doc, item
+			):
+				item_account_wise_cost.setdefault((item.item_code, item.purchase_receipt_item), {})
+				item_account_wise_cost[(item.item_code, item.purchase_receipt_item)].setdefault(
+					account, {"amount": 0.0, "base_amount": 0.0}
+				)
 
-					if total_item_cost > 0:
-						item_account_wise_cost[(item.item_code, item.purchase_receipt_item)][
-							account.expense_account
-						]["amount"] += (
-							account.amount * item.get(based_on_field) / total_item_cost
-						)
-
-						item_account_wise_cost[(item.item_code, item.purchase_receipt_item)][
-							account.expense_account
-						]["base_amount"] += (
-							account.base_amount * item.get(based_on_field) / total_item_cost
-						)
-					else:
-						item_account_wise_cost[(item.item_code, item.purchase_receipt_item)][
-							account.expense_account
-						]["amount"] += item.applicable_charges
-						item_account_wise_cost[(item.item_code, item.purchase_receipt_item)][
-							account.expense_account
-						]["base_amount"] += item.applicable_charges
+				item_account_wise_cost[(item.item_code, item.purchase_receipt_item)][account][
+					"amount"
+				] += amount
+				item_account_wise_cost[(item.item_code, item.purchase_receipt_item)][account][
+					"base_amount"
+				] += base_amount
 
 	return item_account_wise_cost
+
+
+def split_applicable_charges_by_account(landed_cost_voucher_doc, item):
+	"""Split one Landed Cost Item's reconciled `applicable_charges` across the voucher's
+	charge accounts, preserving the total to the cent.
+
+	`applicable_charges` is a single company-currency figure covering *all* charge rows,
+	so when a voucher carries more than one charge account the figure has to be
+	apportioned. Each slice is rounded to currency precision and the remainder is pushed
+	onto the last account — the same last-row-absorbs-the-difference rule the voucher
+	itself applies across items. The slices therefore re-add to `applicable_charges`
+	exactly, and summed over items to `total_taxes_and_charges`.
+
+	Yields `(expense_account, amount, base_amount)`. `amount` is in the charge account's
+	currency, `base_amount` in company currency.
+	"""
+	precision = get_field_precision(
+		frappe.get_meta("Landed Cost Item").get_field("applicable_charges"),
+		currency=erpnext.get_company_currency(landed_cost_voucher_doc.company),
+	)
+
+	applicable_charges = flt(item.applicable_charges, precision)
+	total_taxes_and_charges = flt(landed_cost_voucher_doc.total_taxes_and_charges)
+	taxes = landed_cost_voucher_doc.taxes
+
+	rows = []
+	allocated = 0.0
+
+	for idx, account in enumerate(taxes):
+		if idx == len(taxes) - 1:
+			# Last row absorbs the rounding remainder.
+			base_amount = flt(applicable_charges - allocated, precision)
+		elif total_taxes_and_charges:
+			base_amount = flt(
+				applicable_charges * flt(account.base_amount) / total_taxes_and_charges, precision
+			)
+		else:
+			base_amount = 0.0
+
+		allocated = flt(allocated + base_amount, precision)
+
+		# Convert back to the charge account's own currency. `exchange_rate` is forced to
+		# 1 whenever the account currency matches the company currency, so this is an
+		# identity for the single-currency case rather than a second source of drift.
+		exchange_rate = flt(account.exchange_rate) or 1
+		amount = flt(base_amount / exchange_rate, precision)
+
+		rows.append((account.expense_account, amount, base_amount))
+
+	return rows
 
 
 @erpnext.allow_regional


### PR DESCRIPTION
Fixes pps190/next#721

## The defect

A Landed Cost Voucher's per-item charge share is calculated **twice, by two paths, with two rounding policies**.

**Valuation path (correct)** — `set_applicable_charges_on_item` rounds each share to field precision, then pushes the leftover onto the last item row. Stored `applicable_charges` therefore sum **exactly** to `total_taxes_and_charges`, and this is what drives stock valuation.

**GL path (defective)** — `get_item_account_wise_additional_cost` ignored that reconciled value and re-derived each share as a raw float:

```python
account.amount * item.get(based_on_field) / total_item_cost
```

No rounding, no remainder reconciliation. The reconciled figure was referenced only in the dead `else` branch that runs when `total_item_cost <= 0`.

Each Purchase Receipt then rounds its own slice on write, so the remainder the voucher assigned to its last row never reaches the ledger.

## Effect

- The landed-cost clearing account does not self-clear — a cent or two survives, needing a manual write-off JE per shipment.
- The receipt's GL no longer balances on its own, so `round_off_debit_credit` silently plugs the gap with a spurious Round Off entry.
- **Inventory valuation is not affected** — the valuation path is the correct one. The error lands entirely in the clearing and round-off accounts.
- Severity scales with receipts per voucher. One receipt usually nets out; the largest affected production voucher spanned 58 rows across 27 receipts.

Not a multi-currency problem — it reproduces at `exchange_rate = 1` with `account_currency == company_currency`.

## The fix

`get_item_account_wise_additional_cost` now reads `applicable_charges`. When a voucher carries more than one charge account, `split_applicable_charges_by_account` apportions that single company-currency figure between the accounts using the **same last-row-absorbs-the-remainder rule** the voucher applies across items, so the slices re-add exactly.

`credit_in_account_currency` is now rounded on write as well. It previously received the raw float while `credit` was rounded by the GL row writer, so the two columns disagreed on every row even at rate 1:

```sql
-- credit: 4.33   credit_in_account_currency: 4.333333333
```

### Second bug found while fixing this

The old code apportioned by the item's `amount` **even under "Distribute Manually"**, ignoring the split the user typed. A deliberate 90/10 split posted as 50/50 — and because the receipt's own GL then didn't balance, it threw:

```
ValidationError: Debit and Credit not equal for Purchase Receipt #... Difference is 40.0
```

Reading the reconciled figure fixes this mode too.

## Verification

Reproduced and fixed on real submitted documents (one voucher, three receipts, 10.00 of charges):

| | slices | total |
|---|---|---|
| LCV `applicable_charges` | 3.33 / 3.33 / 3.34 | 10.00 ✅ |
| GL **before** | 3.33 / 3.33 / 3.33 | **9.99** ❌ (0.01 stranded, `credit_in_account_currency` = 3.333333333) |
| GL **after** | 3.33 / 3.33 / 3.34 | 10.00 ✅ (both currency columns clean) |

Manual distribution, same setup: user types 90/10 → **before** throws the 40.0 imbalance, **after** posts 90/10.

Three regression tests added to `test_landed_cost_voucher.py`. They use **three separate receipts** deliberately: within a single receipt ERPNext merges same-account GL rows before writing, which hides the per-slice rounding.

**Test run — `Ran 13 tests ... OK`** on a clean frappe+erpnext site.

Confirmed the tests actually catch this bug rather than passing vacuously: reverting only `purchase_receipt.py` to the previous commit turns exactly the three new tests red (`failures=2, errors=1`) while all 10 pre-existing tests in the module stay green.

## Both callers benefit

`get_item_account_wise_additional_cost` is shared by Purchase Receipt and Purchase Invoice (`update_stock=1`), so the fix covers both.

## Upstream

Unfixed on `version-14`, `version-15-hotfix` and `develop`. On `develop` the function was refactored and renamed to `get_item_account_wise_lcv_entries`, but the offending division survived untouched — nothing to backport.

Historical residuals already on the books are cleared by a companion patch in pps190/next#729.

> **Deploy this PR first**, then pps190/next#729. Running that cleanup against the unfixed code here would clear the residuals only for new ones to accumulate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

